### PR TITLE
Should fix wiki hyperlinks

### DIFF
--- a/docs/_homepage.mdx
+++ b/docs/_homepage.mdx
@@ -1,6 +1,6 @@
 Welcome to the AutoModpack documentation!
 
-If you are new to AutoModpack, we recommend starting with the [Quick Start Guide](quick-start) to get familiar with the basics of using AutoModpack.
+If you are new to AutoModpack, we recommend starting with the [Quick Start Guide](docs/quick-start) to get familiar with the basics of using AutoModpack.
 
 If you are looking for more detailed information, you can find it in the `👨‍💻 Technical Details` section.
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -2,7 +2,7 @@
 No, it's both. You need to have it installed on server as well as on client.
 
 ### How do i add client only mods to the modpack? (e.g. server crashes with some mod but i want it for clients)
-Take a look at [modpack creation page](techinicals/modpack-creation).
+Take a look at [modpack creation page](technicals/modpack-creation).
 
 ### How to restrict access to my modpack?
 Enable `validateSecrets` in the [config](configuration/server-config), turn on `online-mode` in the server.properties and enable whitelist or ban someone.


### PR DESCRIPTION
fixed one typo and added "docs/" again on quick start guide link, because without it mislead to an 404