### PR TITLE
Auto apply resource packs

### DIFF
--- a/core/src/main/java/pl/skidam/automodpack_core/Constants.java
+++ b/core/src/main/java/pl/skidam/automodpack_core/Constants.java
@@ -47,6 +47,7 @@ public class Constants {
 	public static Path hashCacheDBFile = cacheDir.resolve("hash-cache.db");
 	public static Path modCacheDBFile = cacheDir.resolve("mod-cache.db");
 	public static Path clientSelectionFile = automodpackDir.resolve("automodpack-client-selection.json");
+	public static Path clientResourcePackStateFile = automodpackDir.resolve("automodpack-client-resourcepacks.json");
 	public static Path clientDummyFilesFile = automodpackDir.resolve("automodpack-dummy-files.json");
 	public static Path clientDeletionTimeStamps = automodpackDir.resolve("automodpack-deletion-timestamps-files.json");
 	public static Path serverCoreConfigFile = automodpackDir.resolve("automodpack-core.json");

--- a/core/src/main/java/pl/skidam/automodpack_core/config/ConfigUtils.java
+++ b/core/src/main/java/pl/skidam/automodpack_core/config/ConfigUtils.java
@@ -45,6 +45,7 @@ public class ConfigUtils {
 				group.overwriteEditableFiles = normalizePathRules(group.overwriteEditableFiles, "overwriteEditableFiles", pattern);
 				group.forceCopyFilesToStandardLocation = normalizePathRules(group.forceCopyFilesToStandardLocation, "forceCopyFilesToStandardLocation",
 						pattern);
+				if (group.autoApplyResourcePacks == null) group.autoApplyResourcePacks = new LinkedHashSet<>();
 			}
 		}
 

--- a/core/src/main/java/pl/skidam/automodpack_core/config/Jsons.java
+++ b/core/src/main/java/pl/skidam/automodpack_core/config/Jsons.java
@@ -202,6 +202,12 @@ public class Jsons {
 		public Set<String> allowEditsInFiles = Set.of();
 		public Set<String> overwriteEditableFiles = Set.of();
 		public Set<String> forceCopyFilesToStandardLocation = Set.of();
+
+		// Filenames of this group's own resourcepack files (must be a subset of syncedFiles' matches)
+		// that the client should automatically enable in-game when this group is active. Left null
+		// (rather than defaulting to an empty set) so ConfigUtils.normalizeServerConfig can tell "key
+		// missing from an old config file" apart from "key present and empty", and add it to disk.
+		public Set<String> autoApplyResourcePacks = null;
 	}
 
 	public static class ServerCoreConfigFields {
@@ -270,6 +276,11 @@ public class Jsons {
 			public Set<String> breaksWith = Set.of();
 			public Set<String> requires = Set.of();
 
+			// Filenames (see ModpackContentItem.file) of this group's own resourcepack files that the
+			// client should automatically enable in-game when this group is active. Mirrors
+			// GroupDeclaration.autoApplyResourcePacks.
+			public Set<String> autoApplyResourcePacks = Set.of();
+
 			// Populated by the scanner: relative paths of the ModpackContentItems in this group.
 			public Set<String> files = new HashSet<>();
 
@@ -283,6 +294,7 @@ public class Jsons {
 				this.recommended = declaration.recommended;
 				this.breaksWith = declaration.breaksWith;
 				this.requires = declaration.requires;
+				this.autoApplyResourcePacks = declaration.autoApplyResourcePacks == null ? Set.of() : declaration.autoApplyResourcePacks;
 			}
 		}
 
@@ -383,6 +395,25 @@ public class Jsons {
 
 			public ModpackSelection(Set<String> selectedGroups) {
 				this.selectedGroups = selectedGroups;
+			}
+		}
+	}
+
+	// Per-modpack record of resource pack filenames (see GroupDeclaration.autoApplyResourcePacks)
+	// the player manually disabled after AutoModpack auto-enabled them, so later joins don't
+	// re-enable something the player deliberately turned off. Keyed by modpack id, same as
+	// ClientSelectionManagerFields.
+	public static class ClientResourcePackStateFields {
+		public int DO_NOT_CHANGE_IT = 1; // file version
+		public Map<String, ModpackResourcePackState> modpacks = new HashMap<>();
+
+		public static class ModpackResourcePackState {
+			public Set<String> userDisabled = new HashSet<>();
+
+			public ModpackResourcePackState() {}
+
+			public ModpackResourcePackState(Set<String> userDisabled) {
+				this.userDisabled = userDisabled;
 			}
 		}
 	}

--- a/core/src/main/java/pl/skidam/automodpack_core/modpack/ClientResourcePackStateManager.java
+++ b/core/src/main/java/pl/skidam/automodpack_core/modpack/ClientResourcePackStateManager.java
@@ -1,0 +1,64 @@
+package pl.skidam.automodpack_core.modpack;
+
+import static pl.skidam.automodpack_core.Constants.LOGGER;
+import static pl.skidam.automodpack_core.Constants.clientResourcePackStateFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import pl.skidam.automodpack_core.config.ConfigTools;
+import pl.skidam.automodpack_core.config.Jsons;
+
+/**
+ * Remembers, per modpack, which auto-applied resource pack filenames the player manually disabled
+ * in-game, so a later join doesn't re-enable something they deliberately turned off.
+ */
+public class ClientResourcePackStateManager {
+
+	private static final ClientResourcePackStateManager INSTANCE = new ClientResourcePackStateManager(clientResourcePackStateFile);
+
+	private final Path stateFile;
+	private final Jsons.ClientResourcePackStateFields state;
+
+	public static ClientResourcePackStateManager getManager() {
+		return INSTANCE;
+	}
+
+	ClientResourcePackStateManager(Path stateFile) {
+		this.stateFile = stateFile;
+		this.state = ConfigTools.readOrCreate(stateFile, Jsons.ClientResourcePackStateFields.class, Jsons.ClientResourcePackStateFields::new);
+		if (this.state.modpacks == null) this.state.modpacks = new HashMap<>();
+	}
+
+	public Set<String> getDisabled(String modpackId) {
+		if (modpackId == null || modpackId.isBlank()) return Set.of();
+		var modpackState = state.modpacks.get(modpackId);
+		return modpackState == null || modpackState.userDisabled == null ? Set.of() : modpackState.userDisabled;
+	}
+
+	/** Records that the player turned this resource pack off; future joins will leave it disabled. */
+	public void markDisabled(String modpackId, String fileName) {
+		if (modpackId == null || modpackId.isBlank() || fileName == null || fileName.isBlank()) return;
+		state.modpacks.computeIfAbsent(modpackId, id -> new Jsons.ClientResourcePackStateFields.ModpackResourcePackState(new HashSet<>())).userDisabled.add(fileName);
+		save();
+	}
+
+	/** Clears a remembered disable, e.g. if the player re-enabled the pack manually. */
+	public void markEnabled(String modpackId, String fileName) {
+		if (modpackId == null || modpackId.isBlank() || fileName == null || fileName.isBlank()) return;
+		var modpackState = state.modpacks.get(modpackId);
+		if (modpackState == null || modpackState.userDisabled == null) return;
+		if (modpackState.userDisabled.remove(fileName)) save();
+	}
+
+	public void save() {
+		try {
+			ConfigTools.writeAtomic(stateFile, state);
+		} catch (IOException e) {
+			LOGGER.error("Failed to save client resource pack state", e);
+		}
+	}
+}

--- a/core/src/main/java/pl/skidam/automodpack_core/modpack/ClientSelectionManager.java
+++ b/core/src/main/java/pl/skidam/automodpack_core/modpack/ClientSelectionManager.java
@@ -239,4 +239,37 @@ public class ClientSelectionManager {
 
 		return allowed;
 	}
+
+	/**
+	 * Filenames declared for resource pack auto-apply (GroupDeclaration.autoApplyResourcePacks) by
+	 * whichever of {@code content}'s groups actually have a matching resourcepack item present.
+	 * {@code content} is expected to already be selection-filtered (see filterToSelection), so a
+	 * file only shows up here if its group was selected - this is a pure lookup, not a
+	 * re-resolution of group selection.
+	 */
+	public static Set<String> autoApplyResourcePackFiles(Jsons.ModpackContentFields content) {
+		if (content == null || content.groups == null || content.groups.isEmpty() || content.list == null) return Set.of();
+
+		Set<String> presentResourcePackFiles = new HashSet<>();
+		content.list.forEach(item -> {
+			if ("resourcepack".equals(item.type)) presentResourcePackFiles.add(item.file);
+		});
+		if (presentResourcePackFiles.isEmpty()) return Set.of();
+
+		Set<String> fileNames = new LinkedHashSet<>();
+		content.groups.values().forEach(group -> {
+			if (group == null || group.autoApplyResourcePacks == null || group.autoApplyResourcePacks.isEmpty() || group.files == null) return;
+			for (String file : group.files) {
+				if (!presentResourcePackFiles.contains(file)) continue;
+				String fileName = fileName(file);
+				if (group.autoApplyResourcePacks.contains(fileName)) fileNames.add(fileName);
+			}
+		});
+		return fileNames;
+	}
+
+	private static String fileName(String file) {
+		int lastSlash = file.lastIndexOf('/');
+		return lastSlash < 0 ? file : file.substring(lastSlash + 1);
+	}
 }

--- a/src/main/java/pl/skidam/automodpack/client/resourcepack/ResourcePackAutoApplier.java
+++ b/src/main/java/pl/skidam/automodpack/client/resourcepack/ResourcePackAutoApplier.java
@@ -1,0 +1,101 @@
+package pl.skidam.automodpack.client.resourcepack;
+
+import static pl.skidam.automodpack_core.Constants.LOGGER;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.packs.repository.PackRepository;
+
+import pl.skidam.automodpack_core.config.Jsons;
+import pl.skidam.automodpack_core.modpack.ClientResourcePackStateManager;
+import pl.skidam.automodpack_core.modpack.ClientSelectionManager;
+
+/**
+ * Automatically enables the resource packs a server's modpack groups declare via
+ * GroupDeclaration.autoApplyResourcePacks, and remembers (per modpack) when the player manually
+ * turns one back off so a later join doesn't re-enable it. Only ever touches pack-list entries it
+ * owns; everything else the player has - their own resource packs - is left untouched.
+ *
+ * Must be called on the client thread (see Minecraft#execute).
+ */
+public class ResourcePackAutoApplier {
+
+	private static final String ID_PREFIX = "file/";
+
+	// What we personally applied last time, and for which modpack. Intentionally in-memory only -
+	// reset every launch - so stale entries from a previous server are cleaned up lazily the next
+	// time this runs, rather than requiring a dedicated disconnect hook.
+	private static Set<String> previouslyAppliedFileNames = Set.of();
+	private static String previouslyAppliedModpackId = null;
+
+	public static void apply(Minecraft client, Jsons.ModpackContentFields serverModpackContent) {
+		String modpackId = serverModpackContent.modpackId;
+		Set<String> rawTarget = ClientSelectionManager.autoApplyResourcePackFiles(serverModpackContent);
+		ClientResourcePackStateManager stateManager = ClientResourcePackStateManager.getManager();
+		Set<String> disabled = stateManager.getDisabled(modpackId);
+
+		// Prune remembered disables for packs the server no longer declares, so the state file
+		// doesn't accumulate orphaned entries.
+		for (String fileName : new HashSet<>(disabled)) {
+			if (!rawTarget.contains(fileName)) stateManager.markEnabled(modpackId, fileName);
+		}
+
+		Set<String> target = new LinkedHashSet<>(rawTarget);
+		target.removeAll(disabled);
+
+		PackRepository repository = client.getResourcePackRepository();
+		repository.reload(); // pick up files that were just downloaded/deleted this join - cheap, no reload screen
+		List<String> currentlySelected = List.copyOf(repository.getSelectedIds());
+		List<String> selected = new ArrayList<>(currentlySelected);
+
+		// Detect packs we applied last time (for this same modpack) that are missing now - the
+		// player turned them off themselves. Only counts if the server still wants them; if the
+		// server dropped the pack entirely that's the cleanup case above, not a player action.
+		if (Objects.equals(previouslyAppliedModpackId, modpackId)) {
+			for (String fileName : previouslyAppliedFileNames) {
+				if (!rawTarget.contains(fileName)) continue;
+				if (!selected.contains(ID_PREFIX + fileName)) {
+					stateManager.markDisabled(modpackId, fileName);
+					target.remove(fileName);
+				}
+			}
+		}
+
+		// Lazy revert: drop whatever we previously enabled that isn't part of this join's target -
+		// covers both a switch to a different modpack/server and files the server retired.
+		for (String fileName : previouslyAppliedFileNames) {
+			if (target.contains(fileName)) continue;
+			selected.remove(ID_PREFIX + fileName);
+		}
+
+		// Enable the target packs. If one is already present under its own id, leave it exactly
+		// where it is instead of forcing a reorder every join.
+		for (String fileName : target) {
+			String id = ID_PREFIX + fileName;
+			if (selected.contains(id)) continue;
+			if (!repository.isAvailable(id)) continue; // not on disk yet
+			selected.add(id); // end of the list = highest priority
+		}
+
+		// Nothing to do - avoid the vanilla "loading resource packs" screen when rejoining with the
+		// same set already active (e.g. reconnecting to the same server with no file changes).
+		if (!selected.equals(currentlySelected)) {
+			repository.setSelected(selected);
+			client.options.updateResourcePacks(repository);
+			client.options.save();
+			client.reloadResourcePacks().exceptionally(e -> {
+				LOGGER.error("Failed to reload resource packs after auto-apply", e);
+				return null;
+			});
+		}
+
+		previouslyAppliedFileNames = target;
+		previouslyAppliedModpackId = modpackId;
+	}
+}

--- a/src/main/java/pl/skidam/automodpack/client/resourcepack/ResourcePackAutoApplier.java
+++ b/src/main/java/pl/skidam/automodpack/client/resourcepack/ResourcePackAutoApplier.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackRepository;
 
 import pl.skidam.automodpack_core.config.Jsons;
@@ -87,7 +88,19 @@ public class ResourcePackAutoApplier {
 		// same set already active (e.g. reconnecting to the same server with no file changes).
 		if (!selected.equals(currentlySelected)) {
 			repository.setSelected(selected);
-			client.options.updateResourcePacks(repository);
+
+			// Inlined equivalent of Options#updateResourcePacks(PackRepository), which only exists on
+			// newer versions - resourcePacks/incompatibleResourcePacks and the Pack accessors used here
+			// have been stable since 1.18.2, so this works across every supported target without a
+			// Stonecutter guard.
+			client.options.resourcePacks.clear();
+			client.options.incompatibleResourcePacks.clear();
+			for (Pack pack : repository.getSelectedPacks()) {
+				if (pack.isFixedPosition()) continue;
+				client.options.resourcePacks.add(pack.getId());
+				if (!pack.getCompatibility().isCompatible()) client.options.incompatibleResourcePacks.add(pack.getId());
+			}
+
 			client.options.save();
 			client.reloadResourcePacks().exceptionally(e -> {
 				LOGGER.error("Failed to reload resource packs after auto-apply", e);

--- a/src/main/java/pl/skidam/automodpack/networking/packet/DataC2SPacket.java
+++ b/src/main/java/pl/skidam/automodpack/networking/packet/DataC2SPacket.java
@@ -11,6 +11,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl;
 import net.minecraft.network.FriendlyByteBuf;
 
+import pl.skidam.automodpack.client.resourcepack.ResourcePackAutoApplier;
 import pl.skidam.automodpack.mixin.core.ClientLoginNetworkHandlerAccessor;
 import pl.skidam.automodpack.networking.ModPackets;
 import pl.skidam.automodpack.networking.client.ClientLoginDisconnect;
@@ -127,7 +128,10 @@ public class DataC2SPacket {
 				}
 
 				UpdateType restartType = updater.reconcileReceivedManifest();
-				if (restartType == null) return buildResponse(false);
+				if (restartType == null) {
+					client.execute(() -> ResourcePackAutoApplier.apply(client, serverModpackContent));
+					return buildResponse(false);
+				}
 
 				new ScreenManager().waiting();
 				disconnectImmediately(handler);


### PR DESCRIPTION
New per group server's configuration key, which looks like that:
```      
"autoApplyResourcePacks": [
  "FreshAnimations_v1.10.5.zip",
  "FA+Objects-v2.1.2.zip",
  "+1.21.3 Fresh Moves v3.1.1 (With Animated Eyes).zip"
]
```

Pass names of resource packs from group's "resourcepacks" folder.

What does it do:
- Create when run first time field "autoApplyResourcePacks": []
- When joining AutoModpack's server - automatically applying configured resource packs 
- Respect user's choice - if user disabled resource pack, which was applied by AutoModpack - keeps it disabled
- Identifying resourcepacks not by hash, but by their file name - prevents triggering re-apply logic for users, who disabled RP if server's owner upload new version of same RP with same name. Keeps original AutoModpack download approach
- Do not unload resourcepacks, until user connects to another AutoModpack server
- Do not touch user's own resource packs. 
